### PR TITLE
Update documentation to match recent meta-updater

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,7 +17,7 @@ Install the OpenEmbedded build dependencies:
 A convenience script is provided to set up your environment to produce OTA-enabled image
 for your machine:
 
-    source meta-updater/scripts/envsetup.sh <machine> # One of minnowboard, raspberrypi, or qemux86-64
+    source meta-updater/scripts/envsetup.sh <machine> # One of intel-corei7-64 (for Minnowboard), raspberrypi3, or qemux86-64
 
 
 Then you can build the required image (core-image-minimal is a good start)


### PR DESCRIPTION
Commit #bae52014 in meta-updater changes the envsetup.sh script to require a
Yocto MACHINE rather than our own name for target boards.

Change-Id: I051b34dc00d4c08c1835eadab2da12c8d46c435a