### PR TITLE
rocko.xml: Add layers for Renesas and AGL

### DIFF
--- a/rocko.xml
+++ b/rocko.xml
@@ -3,6 +3,7 @@
 	<remote name="github" fetch="https://github.com" pushurl="ssh://git@github.com" />
 	<remote name="yocto" fetch="https://git.yoctoproject.org/git/" />
 	<remote name="openembedded" fetch="git://git.openembedded.org/" />
+	<remote name="agl" fetch="https://gerrit.automotivelinux.org/gerrit/" />
 
 	<!-- Core layers: poky and meta-oe -->
 	<project path="poky" name="poky" remote="yocto" revision="rocko" />
@@ -13,10 +14,12 @@
 	<project path="meta-updater-raspberrypi" name="advancedtelematic/meta-updater-raspberrypi" remote="github" revision="rocko" />
 	<project path="meta-updater-minnowboard" name="advancedtelematic/meta-updater-minnowboard" remote="github" revision="rocko" />
 	<project path="meta-updater-qemux86-64" name="advancedtelematic/meta-updater-qemux86-64" remote="github" revision="rocko" />
+	<project path="meta-updater-porter" name="advancedtelematic/meta-updater-porter" remote="github" revision="rocko" />
 
 	<!-- BSP layers -->
 	<project path="meta-raspberrypi" name="meta-raspberrypi" remote="yocto" revision="rocko" />
 	<project name="meta-intel" path="meta-intel" remote="yocto" revision="rocko" />
+	<project name="AGL/meta-renesas" path="meta-renesas" remote="agl" revision="master" />
 
 	<!-- Extra layers -->
 	<project path="meta-rust" name="meta-rust/meta-rust" remote="github" revision="505ba7a172a3694d259d768aa837a0060c415750"/>


### PR DESCRIPTION
Update rocko.xml and add Yocto/OE layers related to
Renesas boards and AGL.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>