### PR TITLE
rocko.xml: Remove meta-rust

### DIFF
--- a/rocko.xml
+++ b/rocko.xml
@@ -21,7 +21,5 @@
 	<project name="meta-intel" path="meta-intel" remote="yocto" revision="rocko" />
 	<project name="AGL/meta-renesas" path="meta-renesas" remote="agl" revision="master" />
 
-	<!-- Extra layers -->
-	<project path="meta-rust" name="meta-rust/meta-rust" remote="github" revision="505ba7a172a3694d259d768aa837a0060c415750"/>
 </manifest>
 


### PR DESCRIPTION
Recipe RVI SOTA Client has been removed form Yocto/OE
meta-updater and layer meta-rust is no longer needed
as a dependency.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>