### PR TITLE
Use meta-raspberrypi's thud branch

### DIFF
--- a/thud.xml
+++ b/thud.xml
@@ -17,7 +17,6 @@
 	<project path="meta-updater-qemux86-64" name="advancedtelematic/meta-updater-qemux86-64" />
 
 	<!-- BSP layers -->
-	<!-- meta-raspberrypi pinned to master for now, pending their release of 'thud' -->
-	<project name="meta-raspberrypi" remote="yocto" revision="master" />
+	<project name="meta-raspberrypi" remote="yocto" />
 	<project name="meta-intel" remote="yocto" />
 </manifest>


### PR DESCRIPTION
It's out now.

Haven't tried yet but it can't be worse than using master which is completely broken:

https://main.gitlab.in.here.com/olp/edge/ota/connect/client/meta-updater/-/jobs/210537